### PR TITLE
Fixed pinned rows

### DIFF
--- a/src/grid/gridBodyComp.tsx
+++ b/src/grid/gridBodyComp.tsx
@@ -120,8 +120,8 @@ const GridBodyComp = () => {
   );
 
   const getTopStyle: any = createMemo(() => ({
-    height: getTopHeight(),
-    "min-height": getTopHeight(),
+    height: `${getTopHeight()}px`,
+    "min-height": `${getTopHeight()}px`,
     display: getTopDisplay(),
     "overflow-y": getTopAndBottomOverflowY(),
   }));
@@ -133,8 +133,8 @@ const GridBodyComp = () => {
   }));
 
   const getBottomStyle: any = createMemo(() => ({
-    height: getBottomHeight(),
-    "min-height": getBottomHeight(),
+    height: `${getBottomHeight()}px`,
+    "min-height": `${getBottomHeight()}px`,
     display: getBottomDisplay(),
     "overflow-y": getTopAndBottomOverflowY(),
   }));


### PR DESCRIPTION
In `GridBodyComp`, the `getTopHeight()` and `getBottomHeight()` signals store a number, but are used to set the "height" and "min-height" CSS properties in `getTopStyle()` and `getBottomStyle()` repectively.
I made sure to specify the pixel CSS unit for those signals.
(Otherwise the pinned rows would have stayed at 0 height)